### PR TITLE
fix default cannot be an empty string

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ class Xlm2Object {
   
     for(const key in this.mapping) {
       const extraction = this.extractKey(this.mapping[key])
-      if (extraction)
+      if (extraction !== undefined)
         object[key] = extraction;
     }
   
@@ -73,7 +73,7 @@ class Xlm2Object {
   
     if (options.mapping)
       return transform(this._extracItemsKey(options));
-  
+
     if (options.path)
       return transform(this._extractPlainKey(options));
   
@@ -89,7 +89,7 @@ class Xlm2Object {
   extractNodes(path, tolerance=false) {
     const select = xpath.useNamespaces(this.options.namespaces);
     const nodes = select(path, this.doc);
-  
+
     const isTolerant = this.options.tolerance || tolerance
     
     if (nodes.length === 0 && !isTolerant)
@@ -106,7 +106,7 @@ class Xlm2Object {
   */
   _extractPlainKey({path, array=false, tolerance=false}) {
     const nodes = this.extractNodes(path, tolerance);
-    
+
     const value = this._extractValue(nodes, (node) => node.nodeValue)
 
     return value;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "utils-xml2object",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "utils-xml2object",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "description": "Extract object from xml using xpath syntax",
   "main": "index.js",
   "homepage": "https://github.com/stanBienaives/xml2object",

--- a/test/test-extrator.js
+++ b/test/test-extrator.js
@@ -471,3 +471,23 @@ test('should extract recursive tree', (t) => {
   t.is(extractor.docs[0]._childrens.length, 1)
 
 });
+
+test('Self closing elements should be supported', (t) => {
+
+  const xml = "\
+<HEAD> \
+  <TITLE>My title</TITLE> \
+  <VERSION> qspdokqsdpokqs </VERSION>\
+</HEAD>"
+
+  const extractor = xml2Obj.extract(xml, {
+      title: '/HEAD/TITLE/text()',
+      version: {
+        path: '/HEAD/VERSION',
+        default: '',
+      }
+  })
+
+  t.is(extractor.title, 'My title')
+  t.is(extractor.version, '')
+})


### PR DESCRIPTION
Fix:  using empty string as a default value in options does not work properly

undefined is returned



